### PR TITLE
Support layouts relying on stack trace information

### DIFF
--- a/src/NLog.Targets.Syslog/NLog.Targets.Syslog.cs
+++ b/src/NLog.Targets.Syslog/NLog.Targets.Syslog.cs
@@ -94,7 +94,11 @@ namespace NLog.Targets
             string[] formattedLines = logEvent.FormattedMessage.Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);            
             foreach (string fline in formattedLines)
             {
-                var layoutLine = new LogEventInfo(logEvent.Level, logEvent.LoggerName, fline);
+                var layoutLine = new LogEventInfo(level: logEvent.Level, loggerName: logEvent.LoggerName, message: fline);
+                if (logEvent.HasStackTrace)
+                {
+                    layoutLine.SetStackTrace(stackTrace: logEvent.StackTrace, userStackFrame: logEvent.UserStackFrameNumber);
+                }
                 byte[] msg = BuildSyslogMessage(Facility, GetSyslogSeverity(logEvent.Level), DateTime.Now, Sender, Layout.Render(layoutLine));
             	SendMessage(SyslogServer, Port, msg, Protocol, Ssl);
             }

--- a/src/TestApp/NLog.config
+++ b/src/TestApp/NLog.config
@@ -11,7 +11,14 @@
   </extensions>
 
   <targets>
-    <target name="syslog" type="Syslog" syslogserver="127.0.0.1" port="514" facility="Local7" layout="[CustomPrefix] ${machinename} ${message}"/>
+    <target
+      name="syslog"
+      type="Syslog"
+      syslogserver="127.0.0.1"
+      port="514"
+      facility="Local7"
+      sender="MyProgram"
+      layout="[CustomPrefix] ${machinename} ${message} ${callsite} ${exception:format=ToString,StackTrace}" />
   </targets>
 
   <rules>


### PR DESCRIPTION
I was not able to use some Layout Renderers because they require the stack trace information.
