### PR TITLE
Use the same LogEventInfo for all message lines

### DIFF
--- a/src/NLog.Targets.Syslog/NLog.Targets.Syslog.cs
+++ b/src/NLog.Targets.Syslog/NLog.Targets.Syslog.cs
@@ -95,7 +95,7 @@ namespace NLog.Targets
             foreach (var formattedMessageLine in formattedMessageLines)
             {
                 logEvent.Message = formattedMessageLine;
-                var message = BuildSyslogMessage(Facility, GetSyslogSeverity(logEvent.Level), DateTime.Now, Sender, Layout.Render(logEvent));
+                byte[] message = BuildSyslogMessage(Facility, GetSyslogSeverity(logEvent.Level), DateTime.Now, Sender, Layout.Render(logEvent));
                 SendMessage(SyslogServer, Port, message, Protocol, Ssl);
             }
 


### PR DESCRIPTION
So we can preserve all the event info and no need to re-set it.
