### PR TITLE
Add MSBuild step to the build script

### DIFF
--- a/src/NLog.Targets.Syslog/build.bat
+++ b/src/NLog.Targets.Syslog/build.bat
@@ -1,6 +1,7 @@
 @echo off
 echo Building package...
 rmdir /S /Q deploy
+msbuild NLog.Targets.Syslog.csproj /t:Build /p:Configuration=Release /v:minimal /nologo
 ..\..\tools\NuGet.exe pack NLog.Targets.Syslog.csproj -Prop Configuration=Release
 mkdir deploy
 for /f %%a in ('dir /b /s .\*.nupkg') do call move /Y %%a deploy


### PR DESCRIPTION
This allows packaging and upload to nuget without a Visual Studio build first.
