### PR TITLE
Allocate delegates only once in AsyncLogger

### DIFF
--- a/src/NLog.Targets.Syslog/Policies/Throttling.cs
+++ b/src/NLog.Targets.Syslog/Policies/Throttling.cs
@@ -33,11 +33,11 @@ namespace NLog.Targets.Syslog.Policies
             Delay = throttlingConfig.Delay;
         }
 
-        public void Apply<T>(T entry, int waitingLogEntries, Action<T, int> processActionWithTimeout, Action<T> discardAction)
+        public void Apply<T>(int waitingLogEntries, T entry, Action<T, int> processWithTimeoutAction, Action<T> discardAction)
         {
             if (Strategy == ThrottlingStrategy.None || waitingLogEntries < Limit)
             {
-                processActionWithTimeout(entry, Timeout.Infinite);
+                processWithTimeoutAction(entry, Timeout.Infinite);
                 return;
             }
 
@@ -49,7 +49,7 @@ namespace NLog.Targets.Syslog.Policies
             }
 
             ApplyDeferment(waitingLogEntries);
-            processActionWithTimeout(entry, CalculateTimeout(waitingLogEntries));
+            processWithTimeoutAction(entry, CalculateTimeout(waitingLogEntries));
         }
 
         private void ApplyDeferment(int waitingLogEntries)

--- a/src/NLog.Targets.Syslog/Policies/Throttling.cs
+++ b/src/NLog.Targets.Syslog/Policies/Throttling.cs
@@ -33,23 +33,23 @@ namespace NLog.Targets.Syslog.Policies
             Delay = throttlingConfig.Delay;
         }
 
-        public void Apply(int waitingLogEntries, Action<int> nonDiscardActionWithTimeout, Action discardAction)
+        public void Apply<T>(T entry, int waitingLogEntries, Action<T, int> processActionWithTimeout, Action<T> discardAction)
         {
             if (Strategy == ThrottlingStrategy.None || waitingLogEntries < Limit)
             {
-                nonDiscardActionWithTimeout(Timeout.Infinite);
+                processActionWithTimeout(entry, Timeout.Infinite);
                 return;
             }
 
             if (Strategy == ThrottlingStrategy.Discard)
             {
                 InternalLogger.Warn("[Syslog] Applied discard throttling strategy");
-                discardAction();
+                discardAction(entry);
                 return;
             }
 
             ApplyDeferment(waitingLogEntries);
-            nonDiscardActionWithTimeout(CalculateTimeout(waitingLogEntries));
+            processActionWithTimeout(entry, CalculateTimeout(waitingLogEntries));
         }
 
         private void ApplyDeferment(int waitingLogEntries)

--- a/src/TestAppWithGUI/TestAppWithGUI.csproj
+++ b/src/TestAppWithGUI/TestAppWithGUI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <RootNamespace>TestAppWithGui</RootNamespace>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <OutputType>WinExe</OutputType>

--- a/src/TestAppWithGUI/TestAppWithGUI.csproj
+++ b/src/TestAppWithGUI/TestAppWithGUI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <RootNamespace>TestAppWithGui</RootNamespace>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <OutputType>WinExe</OutputType>


### PR DESCRIPTION
This line will allocate a delegate instance for every call, because it has to capture this-reference to call Enqueue (along with capturing `asyncLogEventInfo`):

`void NonDiscardAction(int timeout) => Enqueue(asyncLogEventInfo, timeout);`

Changed to single delegate allocation at startup, by moving allocation into constructor.