### PR TITLE
Add target loading section to sample configuration

### DIFF
--- a/build/scripts/cake.cs
+++ b/build/scripts/cake.cs
@@ -20,7 +20,7 @@ var toBuildFolders = toBuildDirInfo
     .Select(x => x.FullName)
     .ToList();
 
-var perProjectMsBuildSettings = new Dictionary<string, DotNetCoreMSBuildSettings>();
+var perProjectMsBuildSettings = new Dictionary<string, DotNetMSBuildSettings>();
 
 Task("MSBuildSettings")
     .Does(() =>
@@ -129,7 +129,7 @@ Task("MSBuildSettings")
             Information($"Package release notes URL: {packageReleaseNotesUrl}");
             Information(Environment.NewLine);
 
-            perProjectMsBuildSettings[project] = new DotNetCoreMSBuildSettings { NoLogo = true, Verbosity = buildVerbosity }
+            perProjectMsBuildSettings[project] = new DotNetMSBuildSettings { NoLogo = true, Verbosity = buildVerbosity }
                 .WithProperty("AssemblyVersion", assemblyVersion)
                 .WithProperty("FileVersion", assemblyFileVersion)
                 .WithProperty("InformationalVersion", assemblyInformationalVersion)
@@ -157,15 +157,15 @@ Task("Clean")
             .Select(x => x.FullName)
             .ToList();
 
-        var cleanSettings = new DotNetCoreCleanSettings
+        var cleanSettings = new DotNetCleanSettings
         {
-            MSBuildSettings = new DotNetCoreMSBuildSettings { NoLogo = true, Verbosity = buildVerbosity }
+            MSBuildSettings = new DotNetMSBuildSettings { NoLogo = true, Verbosity = buildVerbosity }
         };
 
         foreach (var folder in toCleanFolders)
         {
             Information($"Cleaning project in folder {folder}");
-            DotNetCoreClean(folder, cleanSettings);
+            DotNetClean(folder, cleanSettings);
         }
 
         foreach (var folder in toCleanFolders)
@@ -196,7 +196,7 @@ Task("RestorePackages")
             .ToList();
 
         foreach (var projectToRestore in toRestoreProjects)
-            DotNetCoreRestore(projectToRestore);
+            DotNetRestore(projectToRestore);
     });
 
 Task("Build")
@@ -232,8 +232,8 @@ Task("Test")
         foreach (var folder in testFolders)
         {
             Information(folder);
-            var testSettings = new DotNetCoreTestSettings { NoBuild = true, Configuration = buildConfiguration, Verbosity = buildVerbosity };
-            DotNetCoreTest(folder, testSettings);
+            var testSettings = new DotNetTestSettings { NoBuild = true, Configuration = buildConfiguration, Verbosity = buildVerbosity };
+            DotNetTest(folder, testSettings);
         }
     });
 
@@ -256,14 +256,14 @@ Task("NuGetPack")
 
         foreach (var projectToPack in toPackProjects)
         {
-            var packSettings = new DotNetCorePackSettings
+            var packSettings = new DotNetPackSettings
             {
                 MSBuildSettings = perProjectMsBuildSettings[projectToPack],
                 Configuration = buildConfiguration,
                 NoBuild = true,
                 OutputDirectory = artifactsDir
             };
-            DotNetCorePack(projectToPack, packSettings);
+            DotNetPack(projectToPack, packSettings);
         }
     });
 
@@ -282,8 +282,8 @@ Task("NuGetPush")
         Information($"NuGet source: {nuGetSource}");
 
         var packageSearchPattern = System.IO.Path.Combine(artifactsDir, "*.nupkg");
-        var nuGetPushSettings = new DotNetCoreNuGetPushSettings { Source = nuGetSource, ApiKey = nuGetApiKey };
-        DotNetCoreNuGetPush(packageSearchPattern, nuGetPushSettings);
+        var nuGetPushSettings = new DotNetNuGetPushSettings { Source = nuGetSource, ApiKey = nuGetApiKey };
+        DotNetNuGetPush(packageSearchPattern, nuGetPushSettings);
     });
 
 Task("ZipArtifacts")

--- a/build/scripts/cake.cs
+++ b/build/scripts/cake.cs
@@ -3,7 +3,7 @@ var srcDir = Argument<string>("srcDir");
 var artifactsDir = Argument<string>("artifactsDir");
 var target = Argument<string>("target", "Test");
 var buildConfiguration = Argument<string>("buildConfiguration", "Release");
-var buildVerbosity = (DotNetCoreVerbosity)Enum.Parse(typeof(DotNetCoreVerbosity), Argument<string>("buildVerbosity", "Minimal"));
+var buildVerbosity = (DotNetVerbosity)Enum.Parse(typeof(DotNetVerbosity), Argument<string>("buildVerbosity", "Minimal"));
 var softwareVersion = target.ToLower() == "nugetpack" || target.ToLower() == "nugetpush" ? Argument<string>("softwareVersion") : Argument<string>("softwareVersion", string.Empty);
 var buildId = Argument<int>("buildId", 0);
 var buildNumber = buildId == 0 ? -1 : Argument<int>("buildNumber");
@@ -210,12 +210,12 @@ Task("Build")
 
         foreach (var projectToBuild in toBuildProjects)
         {
-            var buildSettings = new DotNetCoreBuildSettings
+            var buildSettings = new DotNetBuildSettings
             {
                 MSBuildSettings = perProjectMsBuildSettings[projectToBuild],
                 Configuration = buildConfiguration
             };
-            DotNetCoreBuild(projectToBuild, buildSettings);
+            DotNetBuild(projectToBuild, buildSettings);
         }
     });
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,9 @@ Below is a sample NLog.config file:
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:sl="http://www.nlog-project.org/schemas/NLog.Targets.Syslog.xsd">
+  <extensions>
+    <add assembly="NLog.Targets.Syslog"/>
+  </extensions>
   <targets>
     <target xsi:type="Syslog" name="cee-udp">
       <sl:layout xsi:type="SimpleLayout" text="@cee: {&quot;message&quot;: &quot;${message}&quot;}" />

--- a/src/NLog.Targets.Syslog.sln
+++ b/src/NLog.Targets.Syslog.sln
@@ -6,8 +6,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		..\.travis.yml = ..\.travis.yml
 		..\appveyor.yml = ..\appveyor.yml
+		..\docs\configuration.md = ..\docs\configuration.md
 		..\LICENSE = ..\LICENSE
-		..\README.md = ..\README.md
+		..\docs\README.md = ..\docs\README.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{FE11D99F-A094-42A4-9DA4-EFEFA413F674}"


### PR DESCRIPTION
Closes #294

NLog 4.x on .NET Framework attempted to autoload NLog-extension-assemblies automatically at startup. Finding all filenames starting with "NLog" (Ex. NLog.Targets.Syslog.dll)

This works great when using old-style nuget-dependencies, where they were xcopied into the output-folder.

This has changed with new-style-dependencies using `<packagereference>` where nuget-packages uses ntfs-links, and suddenly the NLog-engine needs extra help to discover NLog-extension-assemblies (Because the `NLog.dll` scans its own nuget-cache-folder).

NLog 5.0 has now completely [disabled autoload of NLog-extensions-assemblies](https://nlog-project.org/2021/08/25/nlog-5-0-preview1-ready.html#nlog-extensions-assemblies-will-not-load-automatically), because all new application uses `<packagereference>`, and there is an overhead when doing file-scanning at startup-initialization.

This means extra help is always needed when wanting to use NLog extensions in the NLog.config (When using new csproj-format, independent of NLog 4.x og 5.x):
```xml
  <extensions>
    <add assembly="NLog.Targets.Syslog"/>
  </extensions>
  <targets>
       <target xsi:type="Syslog" name="cee-udp">
       </target>
  </targets>
```

NLog 5.0 also introduces a new way, that is similar to .NET typenames (Then one doesn't have to remember to update `<extensions>`):

```xml
  <targets>
       <target xsi:type="Syslog, NLog.Targets.Syslog" name="cee-udp">
       </target>
  </targets>
```